### PR TITLE
Backport pytz from upstream, and use unofficial whitelist hack

### DIFF
--- a/python/google/appengine/api/appinfo.py
+++ b/python/google/appengine/api/appinfo.py
@@ -486,6 +486,14 @@ _SUPPORTED_LIBRARIES = [
         default_version='1.0',
         ),
     _VersionedLibrary(
+        'pytz',
+        'https://pypi.python.org/pypi/pytz?',
+        'A library for cross-platform timezone calculations',
+        ['2016.4'],
+        latest_version='2016.4',
+        default_version='2016.4',
+        ),
+    _VersionedLibrary(
         'crcmod',
         'http://crcmod.sourceforge.net/',
         'A library for generating Cyclic Redundancy Checks (CRC).',

--- a/python/google/appengine/tools/devappserver2/python/sandbox.py
+++ b/python/google/appengine/tools/devappserver2/python/sandbox.py
@@ -43,7 +43,7 @@ from google.appengine.tools.devappserver2.python import stubs
 CODING_MAGIC_COMMENT_RE = re.compile('coding[:=]\s*([-\w.]+)')
 DEFAULT_ENCODING = 'ascii'
 
-_C_MODULES = frozenset(['cv', 'Crypto', 'lxml', 'numpy', 'PIL'])
+_C_MODULES = frozenset(['cv', 'Crypto', 'lxml', 'numpy', 'PIL', 'pytz'])
 
 NAME_TO_CMODULE_WHITELIST_REGEX = {
     'cv': re.compile(r'cv(\..*)?$'),
@@ -52,6 +52,7 @@ NAME_TO_CMODULE_WHITELIST_REGEX = {
     'pycrypto': re.compile(r'Crypto(\..*)?$'),
     'PIL': re.compile(r'(PIL(\..*)?|_imaging|_imagingft|_imagingmath)$'),
     'ssl': re.compile(r'_ssl$'),
+    'pytz': re.compile(r'pytz(\..*)?$'),
 }
 
 # Maps App Engine third-party library names to the Python package name for


### PR DESCRIPTION
xref [this comment](https://code.google.com/p/googleappengine/issues/detail?id=498#c33) for the unofficial hack until upstream `dev_appserver` officially fixes local `pytz` support.

The `_VersionedLibrary` definition is from the latest version of the SDK.