### PR TITLE
Socket/SSL permissions fix

### DIFF
--- a/python/google/appengine/tools/devappserver2/python/sandbox.py
+++ b/python/google/appengine/tools/devappserver2/python/sandbox.py
@@ -930,6 +930,8 @@ _WHITE_LIST_C_MODULES = [
     '_weakref',
     'zipimport',
     'zlib',
+    '_ssl',
+    '_socket',
 ]
 
 


### PR DESCRIPTION
This pulls in some modifications we used to have as an internal patch that fixes the quite frustrating

```
[Errno 13] Permission denied
```

when making some requests with SSL from `dev_appserver.py`. It comes in two parts; one that replaces the SDK's copy of the Python standard lib `socket.py` with the original, and another that whitelists the relevant C modules if Python was compiled with SSL support (`--with-ssl`) which is generally the case with Brew-installed Python, for example.